### PR TITLE
Add metric offset of 100 when setting default route

### DIFF
--- a/salt/freifunk/base/wireguard/etc/wireguard/gen-config.sh
+++ b/salt/freifunk/base/wireguard/etc/wireguard/gen-config.sh
@@ -10,8 +10,10 @@ print_help() {
 set_vpn_if() {
 	# $1 - interface number
 	vpn="vpn$1"
-	metric=$(( $1 + 1 ))	# used when generating config below
-
+	metric=$(( $1 + 100 ))	# used when generating config below
+				# use metric offset 100 to ensure
+				# no conflics with openvpn
+				
 	# currently wg-quick (command to start vpn manually) does
 	# not cope with this kind of naming. it works only when
 	# config file reflects the interface name despite of that


### PR DESCRIPTION
This metric differs from value in /etc/openvpn/gen-config.sh to ensure that no confics occure when user manually renames the wiregard config. name of wireguard config file is used to derive interface name from.