### PR TITLE
Add nvram config option (fastd_restrict) to deny new unknown backbone connections.

### DIFF
--- a/salt/freifunk/base/apache2/var/www_freifunk/status.cgi
+++ b/salt/freifunk/base/apache2/var/www_freifunk/status.cgi
@@ -6,6 +6,8 @@ export TITLE="Allgemein: Status"
 ddmesh_node="$(nvram get ddmesh_node)"
 eval "$(ddmesh-ipcalc.sh -n "$ddmesh_node")"
 
+fastd_restrict="$(nvram get fastd_restrict)"
+
 . ./cgi-bin-pre.cgi
 
 cat<<EOF
@@ -14,17 +16,17 @@ cat<<EOF
 <fieldset class="bubble">
 <legend>Kontakt</legend>
 <table>
-<TR><th width="250">Name:</th><TD>$(nvram get contact_name)</TD></TR>
-<TR><th width="250">E-Mail:</th><TD>$(nvram get contact_email)</TD></TR>
-<TR><th width="250">Location:</th><TD>$(nvram get contact_location)</TD></TR>
-<TR><th width="250">Note:</th><TD>$(nvram get contact_note)</TD></TR>
+<tr><th width="250">Name:</th><td>$(nvram get contact_name)</td></tr>
+<tr><th width="250">E-Mail:</th><td>$(nvram get contact_email)</td></tr>
+<tr><th width="250">Location:</th><td>$(nvram get contact_location)</td></tr>
+<tr><th width="250">Note:</th><td>$(nvram get contact_note)</td></tr>
 </table>
 </fieldset>
 <br>
 <fieldset class="bubble">
 <legend>Allgemeines</legend>
 <table>
-<TR><th width="250">Internet-Gateway:</th><TD colspan="7">$(
+<tr><th width="250">Internet-Gateway:</th><td colspan="7">$(
 	if [ "$(nvram get ddmesh_disable_gateway)" -eq '0' ]; then
 		vpnservice='openvpn@openvpn-vpn0 openvpn@openvpn-vpn1 wg-quick@vpn0 wg-quick@vpn1'
 		vs='0'
@@ -37,26 +39,26 @@ cat<<EOF
 		vs='0'
 		printf '<img src="/images/no.gif">'
 	fi
-	printf '</TD></TR>\n'
+	printf '</td></tr>\n'
 
 	# Print Selected-Gateway then VPN inactive
 	if [ "$vs" -eq '0' ]; then
 		SELGW="$(cat /var/lib/freifunk/bmxd/gateways | sed -n 's#^[	 ]*=>[	 ]\+\([0-9.]\+\).*$#\1#p')"
 		SELID="$(ddmesh-ipcalc.sh $SELGW)"
 		re='^[0-9]+$'
-		printf '<TR><th>Selected-Gateway:</th><TD colspan="7">%s %s</TD></TR>\n' "$SELGW" "$(if [[ $SELID =~ $re ]]; then printf '(%s)\n' $SELID; fi)"
+		printf '<tr><th>Selected-Gateway:</th><td colspan="7">%s %s</td></tr>\n' "$SELGW" "$(if [[ $SELID =~ $re ]]; then printf '(%s)\n' $SELID; fi)"
 	fi
 )
-<TR><th width="250">Auto-Update:</th><TD colspan="7">$(if [ $(nvram get autoupdate) -eq '1' ]; then printf '<img src="/images/yes.png">'; else printf '<img src="/images/no.gif">'; fi)</TD></TR>
-<TR><th>Knoten-IP-Adresse:</th><TD colspan="7">$_ddmesh_ip ($_ddmesh_node)</TD></TR>
-<TR><th>Nameserver:</th><TD colspan="7">$(grep nameserver /etc/resolv.conf | sed 's#nameserver##g')</TD></TR>
-<TR><th>Ger&auml;telaufzeit:</th><TD colspan="7">$(uptime)</TD></TR>
-<TR><th>Prozesse:</th><TD colspan="7">$(ps --no-headers xa | wc -l)</TD></TR>
-<TR><th>System:</th><TD colspan="7">$(uname -a)</TD></TR>
-<TR><th>Firmware-Version:</th><TD colspan="7">Freifunk Dresden Server Edition - $(cat /etc/freifunk-server-version)</TD></TR>
-<TR><th>Freier Speicher:</th><TD colspan="7"></TD></TR>
-<TR><th width="250"></th><th>Total</th> <th>Used</th> <th>Free</th> <th>Shared</th> <th>Buffered/Cached</th> <th>Available</th><th width="30%">&nbsp;</th></TR>
-$(free | sed -n '2,${s#[ 	]*\(.*\):[ 	]*\([0-9]\+\)[ 	]*\([0-9]\+\)[ 	]*\([0-9]*\)[ 	]*\([0-9]*\)[ 	]*\([0-9]*\)[ 	]*\([0-9]*\)#<TR><th>\1</th><td>\2</td><td>\3</td><td>\4</td><td>\5</td><td>\6</td><td>\7</td><td></td></TR>#g;p}')
+<tr><th width="250">Auto-Update:</th><td colspan="7">$(if [ $(nvram get autoupdate) -eq '1' ]; then printf '<img src="/images/yes.png">'; else printf '<img src="/images/no.gif">'; fi)</td></tr>
+<tr><th>Knoten-IP-Adresse:</th><td colspan="7">$_ddmesh_ip ($_ddmesh_node)</td></tr>
+<tr><th>Nameserver:</th><td colspan="7">$(grep nameserver /etc/resolv.conf | sed 's#nameserver##g')</td></tr>
+<tr><th>Ger&auml;telaufzeit:</th><td colspan="7">$(uptime)</td></tr>
+<tr><th>Prozesse:</th><td colspan="7">$(ps --no-headers xa | wc -l)</td></tr>
+<tr><th>System:</th><td colspan="7">$(uname -a)</td></tr>
+<tr><th>Firmware-Version:</th><td colspan="7">Freifunk Dresden Server Edition - $(cat /etc/freifunk-server-version)</td></tr>
+<tr><th>Freier Speicher:</th><td colspan="7"></td></tr>
+<tr><th width="250"></th><th>Total</th> <th>Used</th> <th>Free</th> <th>Shared</th> <th>Buffered/Cached</th> <th>Available</th><th width="30%">&nbsp;</th></tr>
+$(free | sed -n '2,${s#[ 	]*\(.*\):[ 	]*\([0-9]\+\)[ 	]*\([0-9]\+\)[ 	]*\([0-9]*\)[ 	]*\([0-9]*\)[ 	]*\([0-9]*\)[ 	]*\([0-9]*\)#<tr><th>\1</th><td>\2</td><td>\3</td><td>\4</td><td>\5</td><td>\6</td><td>\7</td><td></td></tr>#g;p}')
 </table>
 </fieldset>
 <br>
@@ -67,13 +69,23 @@ $(
 	services='S40network S41firewall S42firewall6 S52batmand S53backbone-fastd2 S90iperf3 fail2ban bind9 apache2 vnstat monitorix openvpn@openvpn-vpn0 openvpn@openvpn-vpn1 wg-quick@vpn0 wg-quick@vpn1'
 	for s in $services
 	do
-		printf '<TR><th width="250">%s:</th><TD>' "$s"
+		# add service infos
+		SERVICE_INFO=""
+		case "$s" in
+			S53backbone-fastd2)
+				[ "$fastd_restrict" = "1" ] && SERVICE_INFO="No more new connections allowed"
+				;;
+		esac
+
+		printf '<tr><th width="250">%s:</th><td>' "$s"
 		if [ "$(systemctl show -p ActiveState $s | cut -d'=' -f2 | grep -c 'inactive\|failed')" -lt 1 ]; then
 			printf '<img src="/images/yes.png">'
 		else
 			printf '<img src="/images/no.gif">'
 		fi
-		printf '</TD></TR>\n'
+		printf '</td>'
+		printf '<td>%s</td>' "$SERVICE_INFO"
+		printf '</tr>\n'
 	done
 )
 </table>

--- a/salt/freifunk/base/fastd/etc/fastd/cmd2.sh
+++ b/salt/freifunk/base/fastd/etc/fastd/cmd2.sh
@@ -43,6 +43,7 @@ EOM
 }
 
 eval "$(ddmesh-ipcalc.sh -n "$(nvram get ddmesh_node)")"
+fastd_restrict="$(nvram get fastd_restrict)"
 
 case $1 in
 
@@ -69,6 +70,12 @@ case $1 in
  	;;
 
 	verify)
+		# check if further new connections are accepted
+		if [ "$fastd_restrict" = "1" ]; then
+			logger -t fastd "no more connection allowed. ($PEER_ADDRESS:$PEER_PORT key $PEER_KEY)"
+			exit 1;
+		fi
+
 		#if verify-cmd was registerred in fastd.conf
 		logger -t fastd "allow connection from $PEER_ADDRESS:$PEER_PORT key $PEER_KEY"
 

--- a/salt/freifunk/base/nvram/etc/nvram.conf
+++ b/salt/freifunk/base/nvram/etc/nvram.conf
@@ -26,6 +26,11 @@ ifname=eth0
 fastd_secret=
 fastd_public=
 
+# to accept all in comming connection, set this to 0 or remove this line.
+# When set to 1, only already known connections are accepted. this may be used
+# to prevent overloading a server.
+fastd_restrict=0
+
 # gps coordinates. see /var/www/sysinfo.json
 # this functionality is not part of Basic Vserver installation, as this service should only run on one or an backup server.
 gps_latitude=51.033865


### PR DESCRIPTION
This is needed to prevent any new connections for a server. /etc/nvram.conf has a new
option to control fastd verification. See comments in nvram.conf for more infos.