### PR TITLE
Update S40network

### DIFF
--- a/salt/freifunk/base/network/etc/init.d/S40network
+++ b/salt/freifunk/base/network/etc/init.d/S40network
@@ -43,14 +43,23 @@ setup_routing() {
 	# special DNS routing, always via public tunnel if exist.
 	ip rule "$1" lookup public_dns priority 350
 
-	# do not route locally generated icmp-frag-needed for
+	# SE: issue via Max
+	# do not send locally generated icmp-frag-needed for
 	# connections via vpn tunnel through local interface.
 	# Sending packages with internet destinations and locale
 	# source ip (from vpn tunnel provider) lead to blocking
 	# server public ip by Hetzner.
-	# This rule also would send local generated icmp (pings)
+	# ERROR: This rule also would send local generated icmp (pings)
 	# only through vpn tunnel if we have an public_gateway selected.
-	ip rule "$1" iif lo ipproto icmp table public_gateway prio 410
+	# Which means that a ping request to freifunk server would be sent
+	# replies as intented via local interface (ens18)
+	#ip rule "$1" iif lo ipproto icmp table public_gateway prio 410
+	#
+	# so I try to use a different rule, because I assume that the icmp-fragmented packet is
+	# generated for a specific interface by kernel. 
+	# we must ensure, that no such package goes out on wrong interface.
+	ip rule "$1" oif vpn0 ipproto icmp table public_gateway prio 410
+	ip rule "$1" oif vpn1 ipproto icmp table public_gateway prio 411
 
 	#route local and lan traffic through own internet gateway
 	ip rule "$1" iif lo table local_gateway priority 420


### PR DESCRIPTION
change ip rules for icmp fragmented / wireguard issue.
There are still "unreachable" packages, that goes to ens18 instead of vpn0. 
this must be blocked in firewall. (packages for vpn ip range must not go to local interface ens18)

kommt in einem zweiten pull-request.