### PR TITLE
dns: fix openvpn dns: only use IPv4 DNS for vpn.forwarder file.

### DIFF
--- a/salt/freifunk/base/openvpn/etc/openvpn/up.sh
+++ b/salt/freifunk/base/openvpn/etc/openvpn/up.sh
@@ -41,7 +41,8 @@ do
 	logger -t "ovpn up.sh" "$opt=${!opt}"
 
 	x="${!opt}"
-	if [ -n "$(echo "$x" | sed -n '/^dhcp-option DNS/p')" ]; then
+	# only consider IPv4 DNS
+	if [ -n "$(echo "$x" | sed -n '/^dhcp-option DNS[ ]/p')" ]; then
 		dns="${x#*dhcp-option DNS}"
 		dns_list+="$dns;"
 


### PR DESCRIPTION

vpn.forwarder hatte wegen openvpn tunnel IPv6 DNS adressen, eine "6" angehängt, die via open vpn dns-options falsch
gefilter wurde.