### PR TITLE
Update wg_cgi to Version 1.2.1

### DIFF
--- a/salt/freifunk/base/config.jinja
+++ b/salt/freifunk/base/config.jinja
@@ -47,5 +47,5 @@
 {% set chassis = salt['cmd.shell']("hostnamectl status | awk '/Chassis/ {print $2}'") %}
 
 {# wg_accept_cgi Version #}
-{% set wg_accept_cgi_version = 'v1.2.0' %}
-{% set wg_accept_cgi_sha1_hash = 'BDCD17E89B00BFD8325BA9815B8D0C1257B90206' %}
+{% set wg_accept_cgi_version = 'v1.2.1' %}
+{% set wg_accept_cgi_sha1_hash = 'E711E9D7BBC6733F6F8907E3929D71D89E1A625A' %}


### PR DESCRIPTION
Fix wg_cgi, Version 1.2.0 only supported glibc >= 2.29
- Ubuntu 18.04 only has glibc 2.27
- Debian 10 only has 2.28
- Newer versions have >= 2.29