### PR TITLE
Se move fastd wg keys

### DIFF
--- a/salt/freifunk/base/config.jinja
+++ b/salt/freifunk/base/config.jinja
@@ -22,7 +22,6 @@
 
 
 {% set ddmesh_registerkey = salt['cmd.shell']('/usr/local/sbin/uci -qX get ffdd.sys.ddmesh_registerkey') %}
-{% set fastd_secret = salt['cmd.shell']('/usr/local/sbin/uci -qX get ffdd.fastd.secret') %}
 
 {% set servername = salt['cmd.shell']('/usr/local/sbin/uci -qX get ffdd.sys.servername') %}
 {% set hostname = salt['cmd.shell']('cat /etc/hostname') %}

--- a/salt/freifunk/base/config.jinja
+++ b/salt/freifunk/base/config.jinja
@@ -22,7 +22,7 @@
 
 
 {% set ddmesh_registerkey = salt['cmd.shell']('/usr/local/sbin/uci -qX get ffdd.sys.ddmesh_registerkey') %}
-{% set fastd_secret = salt['cmd.shell']('/usr/local/sbin/uci -qX get ffdd.sys.fastd_secret') %}
+{% set fastd_secret = salt['cmd.shell']('/usr/local/sbin/uci -qX get ffdd.fastd.secret') %}
 
 {% set servername = salt['cmd.shell']('/usr/local/sbin/uci -qX get ffdd.sys.servername') %}
 {% set hostname = salt['cmd.shell']('cat /etc/hostname') %}

--- a/salt/freifunk/base/ddmesh/autoconfig.sls
+++ b/salt/freifunk/base/ddmesh/autoconfig.sls
@@ -1,5 +1,5 @@
 {# autoconfigure a new server #}
-{% from 'config.jinja' import ddmesh_registerkey, fastd_secret, nodeid %}
+{% from 'config.jinja' import ddmesh_registerkey, nodeid %}
 
 /usr/local/bin/freifunk-uci_autosetup.sh:
   file.managed:
@@ -8,7 +8,7 @@
     - group: root
     - mode: 755
 
-{% if ddmesh_registerkey == '' or ddmesh_registerkey == '-' or fastd_secret == '' or fastd_secret == '-' %}
+{% if ddmesh_registerkey == '' or ddmesh_registerkey == '-' %}
 ddmesh_autosetup:
   cmd.run:
     - name: /usr/local/bin/freifunk-uci_autosetup.sh
@@ -16,5 +16,4 @@ ddmesh_autosetup:
       - file: /usr/local/bin/freifunk-uci_autosetup.sh
       - file: /etc/config/ffdd
       - sls: uci
-      - sls: fastd
 {% endif %}

--- a/salt/freifunk/base/ddmesh/usr/local/bin/freifunk-uci_autosetup.sh
+++ b/salt/freifunk/base/ddmesh/usr/local/bin/freifunk-uci_autosetup.sh
@@ -10,9 +10,6 @@ export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ddmesh_node="$(uci -qX get ffdd.sys.ddmesh_node)"
 ddmesh_key="$(uci -qX get dffdd.sys.ddmesh_registerkey)"
 
-fastd_secret="$(uci -qX get ffdd.fastd.secret)"
-
-
 if [ -z "$ddmesh_key" ] || [ "$ddmesh_key" = '-' ] || \
 	[ -z "$fastd_secret" ] || [ "$fastd_secret" = '-' ]; then
 
@@ -24,22 +21,6 @@ if [ -z "$ddmesh_key" ] || [ "$ddmesh_key" = '-' ] || \
 		# set ddmesh_node
 		ddmesh_nodeid="$(freifunk-register-local-node.sh | sed -n '/^node=/{s#^.*=##;p}')"
 		[ -n "$ddmesh_nodeid" ] && uci set ffdd.sys.ddmesh_node="$ddmesh_nodeid" || exit 1
-
-		# generate fastd secret & public key
-		fastd --generate-key > /tmp/.ffdd_h.txt
-
-		fastd_secret_key="$(sed -n '/^Secret:/{s#^.*: ##;p}' /tmp/.ffdd_h.txt)"
-		fastd_public_key="$(sed -n '/^Public:/{s#^.*: ##;p}' /tmp/.ffdd_h.txt)"
-
-		rm -f /tmp/.ffdd_h.txt
-
-		# set fastd-key
-		if [ -z "$(uci -qX get ffdd.fastd)" ]; then
-			uci add ffdd fastd
-			uci rename ffdd.@fastd[-1]='fastd'
-		fi
-		uci set ffdd.fastd.secret="$fastd_secret_key"
-		uci set ffdd.fastd.public="$fastd_public_key"
 
 		uci commit
 fi

--- a/salt/freifunk/base/ddmesh/usr/local/bin/freifunk-uci_autosetup.sh
+++ b/salt/freifunk/base/ddmesh/usr/local/bin/freifunk-uci_autosetup.sh
@@ -34,6 +34,10 @@ if [ -z "$ddmesh_key" ] || [ "$ddmesh_key" = '-' ] || \
 		rm -f /tmp/.ffdd_h.txt
 
 		# set fastd-key
+		if [ -z "$(uci -qX get ffdd.fastd)" ]; then
+			uci add ffdd fastd
+			uci rename ffdd.@fastd[-1]='fastd'
+		fi
 		uci set ffdd.fastd.secret="$fastd_secret_key"
 		uci set ffdd.fastd.public="$fastd_public_key"
 

--- a/salt/freifunk/base/ddmesh/usr/local/bin/freifunk-uci_autosetup.sh
+++ b/salt/freifunk/base/ddmesh/usr/local/bin/freifunk-uci_autosetup.sh
@@ -10,7 +10,7 @@ export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ddmesh_node="$(uci -qX get ffdd.sys.ddmesh_node)"
 ddmesh_key="$(uci -qX get dffdd.sys.ddmesh_registerkey)"
 
-fastd_secret="$(uci -qX get ffdd.sys.fastd_secret)"
+fastd_secret="$(uci -qX get ffdd.fastd.secret)"
 
 
 if [ -z "$ddmesh_key" ] || [ "$ddmesh_key" = '-' ] || \
@@ -34,8 +34,8 @@ if [ -z "$ddmesh_key" ] || [ "$ddmesh_key" = '-' ] || \
 		rm -f /tmp/.ffdd_h.txt
 
 		# set fastd-key
-		uci set ffdd.sys.fastd_secret="$fastd_secret_key"
-		uci set ffdd.sys.fastd_public="$fastd_public_key"
+		uci set ffdd.fastd.secret="$fastd_secret_key"
+		uci set ffdd.fastd.public="$fastd_public_key"
 
 		uci commit
 fi

--- a/salt/freifunk/base/ddmesh/var/www_freifunk/status.cgi
+++ b/salt/freifunk/base/ddmesh/var/www_freifunk/status.cgi
@@ -6,7 +6,7 @@ export TITLE="Allgemein &gt; Status"
 ddmesh_node="$(uci -qX get ffdd.sys.ddmesh_node)"
 eval "$(ddmesh-ipcalc.sh -n "$ddmesh_node")"
 
-fastd_restrict="$(uci -qX get ffdd.sys.fastd_restrict)"
+fastd_restrict="$(uci -qX get ffdd.fastd.restrict)"
 
 . ./cgi-bin-pre.cgi
 

--- a/salt/freifunk/base/fastd/etc/fastd/blacklist
+++ b/salt/freifunk/base/fastd/etc/fastd/blacklist
@@ -3,4 +3,4 @@
 #
 # add one IP or peer public key per line without any leading or trailing characters!
 # entries in /etc/fastd/whitelist always has higher priority than 
-# 	/etc/conf/ffdd:fastd_restrict and /etc/fastd/blacklist
+# 	/etc/conf/ffdd:fastd.restrict and /etc/fastd/blacklist

--- a/salt/freifunk/base/fastd/etc/fastd/cmd.sh
+++ b/salt/freifunk/base/fastd/etc/fastd/cmd.sh
@@ -43,7 +43,7 @@ EOM
 }
 
 eval "$(ddmesh-ipcalc.sh -n "$(uci -qX get ffdd.sys.ddmesh_node)")"
-fastd_restrict="$(uci -qX get ffdd.sys.fastd_restrict)"
+fastd_restrict="$(uci -qX get ffdd.fastd.restrict)"
 
 case $1 in
 

--- a/salt/freifunk/base/fastd/etc/fastd/whitelist
+++ b/salt/freifunk/base/fastd/etc/fastd/whitelist
@@ -2,4 +2,4 @@
 #
 # add one IP or peer public key per line without any leading or trailing characters!
 # entries in /etc/fastd/whitelist always has higher priority than 
-# 	/etc/conf/ffdd:fastd_restrict and /etc/fastd/blacklist
+# 	/etc/conf/ffdd:fastd.restrict and /etc/fastd/blacklist

--- a/salt/freifunk/base/fastd/etc/init.d/S53backbone-fastd2
+++ b/salt/freifunk/base/fastd/etc/init.d/S53backbone-fastd2
@@ -33,7 +33,7 @@ fi
 generate_fastd_conf()
 {
 	MTU=1200
-	secret="$(uci -qX get ffdd.sys.fastd_secret)"
+	secret="$(uci -qX get ffdd.fastd.secret)"
 	if [ -z "$secret" ] || [ "$secret" = '-' ]; then
 		logger -t fastd "no secret key - abort"
 		exit 1
@@ -114,6 +114,20 @@ case "$1" in
   start)
 	printf 'Starting backbone...\n'
 
+	# move fastd configs in extra section
+	if [ -z "$(uci -qX get ffdd.fastd)" ]; then
+		uci add ffdd fastd
+		uci rename ffdd.@fastd[-1]="fastd"
+		uci set ffdd.fastd.restrict="$(uci -qX get ffdd.sys.fastd_restrict)"
+		uci delete ffdd.sys.fastd_restrict
+		uci set ffdd.fastd.secret="$(uci -qX get ffdd.sys.fastd_secret)"
+		uci delete ffdd.sys.fastd_secret
+		uci set ffdd.fastd.public="$(uci -qX get ffdd.sys.fastd_public)"
+		uci delete ffdd.sys.fastd_public
+		uci set ffdd.fastd.ext_port="5002"
+		uci commit
+	fi
+
 	generate_fastd_conf
 	# if fastd failes, return error to systemd, else salt always gets an active working status
 	# and would not restart fastd.
@@ -152,7 +166,7 @@ case "$1" in
   ;;
 
   get_public_key)
-	uci -qX get ffdd.sys.fastd_public
+	uci -qX get ffdd.fastd.public
   ;;
 
   add_accept)

--- a/salt/freifunk/base/fastd/etc/init.d/S53backbone-fastd2
+++ b/salt/freifunk/base/fastd/etc/init.d/S53backbone-fastd2
@@ -30,6 +30,30 @@ if [ ! -d "$CONF_DIR"/"$CONF_PEERS" ]; then
 	mkdir -p "$CONF_DIR"/"$CONF_PEERS"
 fi
 
+generate_keys()
+{
+	if [ -z "$(uci -q ffdd.fastd.secret)" -o -z "$(uci -q ffdd.fastd.public)" ]; then
+		# generate fastd secret & public key
+		fastd --generate-key > /tmp/.ffdd_h.txt
+
+		fastd_secret_key="$(sed -n '/^Secret:/{s#^.*: ##;p}' /tmp/.ffdd_h.txt)"
+		fastd_public_key="$(sed -n '/^Public:/{s#^.*: ##;p}' /tmp/.ffdd_h.txt)"
+
+		rm -f /tmp/.ffdd_h.txt
+
+		# set fastd-key
+		if [ -z "$(uci -qX get ffdd.fastd)" ]; then
+			uci add ffdd fastd
+			uci rename ffdd.@fastd[-1]='fastd'
+		fi
+		uci set ffdd.fastd.secret="$fastd_secret_key"
+		uci set ffdd.fastd.public="$fastd_public_key"
+		uci set ffdd.fastd.restrict="0"
+		uci set ffdd.fastd.ext_port="${backbone_server_port}"
+		uci commit
+	fi
+}
+
 generate_fastd_conf()
 {
 	MTU=1200
@@ -114,17 +138,17 @@ case "$1" in
   start)
 	printf 'Starting backbone...\n'
 
-	# move fastd configs in extra section
-	if [ -z "$(uci -qX get ffdd.fastd)" ]; then
-		uci add ffdd fastd
-		uci rename ffdd.@fastd[-1]="fastd"
+	# generate keys if not present
+	generate_keys
+
+	# overwrite values if we have "old" config
+	if [ -n "$(uci -q get ffdd.sys.fastd_secret)" -a -n "$(uci -q get ffdd.sys.fastd_public)" ]; then
 		uci set ffdd.fastd.restrict="$(uci -qX get ffdd.sys.fastd_restrict)"
 		uci delete ffdd.sys.fastd_restrict
 		uci set ffdd.fastd.secret="$(uci -qX get ffdd.sys.fastd_secret)"
 		uci delete ffdd.sys.fastd_secret
 		uci set ffdd.fastd.public="$(uci -qX get ffdd.sys.fastd_public)"
 		uci delete ffdd.sys.fastd_public
-		uci set ffdd.fastd.ext_port="5002"
 		uci commit
 	fi
 

--- a/salt/freifunk/base/fastd/etc/init.d/S53backbone-fastd2
+++ b/salt/freifunk/base/fastd/etc/init.d/S53backbone-fastd2
@@ -32,7 +32,7 @@ fi
 
 generate_keys()
 {
-	if [ -z "$(uci -q ffdd.fastd.secret)" -o -z "$(uci -q ffdd.fastd.public)" ]; then
+	if [ -z "$(uci -q get ffdd.fastd.secret)" -o -z "$(uci -q get ffdd.fastd.public)" ]; then
 		# generate fastd secret & public key
 		fastd --generate-key > /tmp/.ffdd_h.txt
 
@@ -139,6 +139,7 @@ case "$1" in
 	printf 'Starting backbone...\n'
 
 	# generate keys if not present
+	
 	generate_keys
 
 	# overwrite values if we have "old" config

--- a/salt/freifunk/base/uci/etc/config/ffdd
+++ b/salt/freifunk/base/uci/etc/config/ffdd
@@ -42,18 +42,6 @@ config 'ffdd' 'sys'
 	# ALL sub-communities. This enables clients on a sub-communitiy to communitcate with other sub-communities.
 	option 'community_server' '0'
 
-	# this is the secret key which is used to decrypt secured backbone connection
-	# the corresponding public key should be given to the peers, so those can encrpyt/connect to this server
-	# To generate the keys: /etc/init.d/S53backbone-fastd genkey
-	option 'fastd_secret' '-'
-	option 'fastd_public' '-'
-
-	# to accept all in comming backbone connection, set this to 0.
-	# When set to 1, only already known connections are accepted. this may be used
-	# to prevent overloading a server.
-	option 'fastd_restrict' '0'
-	option 'wireguard_restrict' '0'
-
 	# SSH Password-Authentification (0=off 1=on)
 	# To disable tunneled clear text passwords and allow only pub-key auth.
 	option 'ssh_pwauth' '1'
@@ -81,3 +69,35 @@ config 'ffdd' 'sys'
 	option 'contact_location' 'Hosting Provider'
 	option 'contact_email' 'email'
 	option 'contact_note' 'VPN X'
+
+config fastd 'fastd'
+	# this is the secret key which is used to decrypt secured backbone connection
+	# the corresponding public key should be given to the peers, so those can encrpyt/connect to this server
+	# To generate the keys: /etc/init.d/S53backbone-fastd genkey
+	option 'secret' '-'
+	option 'public' '-'
+
+	# to accept all in comming backbone connection, set this to 0.
+	# When set to 1, only already known connections are accepted. this may be used
+	# to prevent overloading a server.
+	option 'restrict' '0'
+
+	# ext_port is retured when user registers with backbone
+	# option 'ext_port' '5002'
+
+config wireguard 'wireguard'
+	# generated when no key was stored
+	#option 'secret' ''
+	#option 'public' ''
+
+	# to accept all in comming backbone connection, set this to 0.
+	# When set to 1, only already known connections are accepted. this may be used
+	# to prevent overloading a server.
+	option 'restrict' '0'
+
+	# when wg config was not used, it is purged after unused_days
+	option 'unused_days' '30'
+
+	# ext_port is retured when user registers with backbone
+	option 'ext_port' '5003'
+

--- a/salt/freifunk/base/uci/usr/local/bin/nvram-migration.sh
+++ b/salt/freifunk/base/uci/usr/local/bin/nvram-migration.sh
@@ -21,11 +21,11 @@ if [ -f /etc/nvram.conf ]; then
 
 	uci set ffdd.sys.ifname="$(nvram_get ifname)"
 
-	uci set ffdd.sys.fastd_secret="$(nvram_get fastd_secret)"
-	uci set ffdd.sys.fastd_public="$(nvram_get fastd_public)"
-	uci set ffdd.sys.fastd_restrict="$(nvram_get fastd_restrict)"
+	#uci set ffdd.sys.fastd_secret="$(nvram_get fastd_secret)"
+	#uci set ffdd.sys.fastd_public="$(nvram_get fastd_public)"
+	#uci set ffdd.sys.fastd_restrict="$(nvram_get fastd_restrict)"
 
-	uci set ffdd.sys.wireguard_secret="$(nvram_get wireguard_secret)"
+	#uci set ffdd.sys.wireguard_secret="$(nvram_get wireguard_secret)"
 
 	uci set ffdd.sys.ssh_pwauth="$(nvram_get ssh_pwauth)"
 

--- a/salt/freifunk/base/uci/usr/local/bin/uci_check_config_options.sh
+++ b/salt/freifunk/base/uci/usr/local/bin/uci_check_config_options.sh
@@ -7,7 +7,6 @@
 
 	test -z "$(uci -qX get ffdd.sys.devmode)" && uci -q set ffdd.sys.devmode=0
 	test -z "$(uci -qX get ffdd.sys.apache_ddos_prevent)" && uci -q set ffdd.sys.apache_ddos_prevent=1
-	test -z "$(uci -qX get ffdd.sys.wireguard_restrict)" && uci -q set ffdd.sys.wireguard_restrict=0
 
 	test -z "$(uci -qX get ffdd.sys.network_id)" && uci -q set ffdd.sys.network_id=0
 	test -z "$(uci -qX get ffdd.sys.community_server)" && uci -q set ffdd.sys.community_server=0
@@ -22,6 +21,7 @@
 
 	test -z "$(uci -qX get ffdd.wireguard.unused_days)" && uci -q set ffdd.wireguard.unused_days=30
 	test -z "$(uci -qX get ffdd.wireguard.ext_port)" && uci -q set ffdd.wireguard.ext_port=5003
+	test -z "$(uci -qX get ffdd.wireguard.restrict)" && uci -q set ffdd.wireguard.restrict=0
 
 
 ## finish / save uci config

--- a/salt/freifunk/base/wireguard/etc/config/wg_cgi
+++ b/salt/freifunk/base/wireguard/etc/config/wg_cgi
@@ -1,7 +1,7 @@
 config uci 'uci'
         option node_id 'ffdd.sys.ddmesh_node'
         option wg_public_key 'ffdd.wireguard.public'
-        option wg_restrict 'ffdd.sys.wireguard_restrict'
+        option wg_restrict 'ffdd.wireguard.restrict'
         option wg_ext_port 'ffdd.wireguard.ext_port'
 
 config sh 'sh'

--- a/salt/freifunk/base/wireguard/usr/local/bin/wg-backbone.sh
+++ b/salt/freifunk/base/wireguard/usr/local/bin/wg-backbone.sh
@@ -27,6 +27,15 @@ start_wg()
 		uci -q rename ffdd.@wireguard[-1]='wireguard'
 	fi
 
+	# upgrade: move config option 'restrict'
+	if [ -z "$(uci -q get ffdd.wireguard.restrict)" ]; then
+		restrict="$(uci -q get ffdd.sys.wireguard_restrict)"
+		test -z "$restrict" && restrict='0'
+		uci set ffdd.wireguard.restrict="$restrict"
+		uci -q delete ffdd.sys.wireguard_restrict
+		uci commit
+	fi
+
 	# create key
 	secret="$(uci -q get ffdd.wireguard.secret)"
 	if [ -z "$secret" ]; then

--- a/salt/freifunk/base/wireguard/usr/local/bin/wg-backbone.sh
+++ b/salt/freifunk/base/wireguard/usr/local/bin/wg-backbone.sh
@@ -28,10 +28,8 @@ start_wg()
 	fi
 
 	# upgrade: move config option 'restrict'
-	if [ -z "$(uci -q get ffdd.wireguard.restrict)" ]; then
-		restrict="$(uci -q get ffdd.sys.wireguard_restrict)"
-		test -z "$restrict" && restrict='0'
-		uci set ffdd.wireguard.restrict="$restrict"
+	if [ -n "$(uci -q get ffdd.sys.wireguard_restrict)" ]; then
+		uci set ffdd.wireguard.restrict="$(uci -q get ffdd.sys.wireguard_restrict)"
 		uci -q delete ffdd.sys.wireguard_restrict
 		uci commit
 	fi


### PR DESCRIPTION
Bitte schau dir mal meine änderungen an.

ich habe in der /etc/config/ffdd  das fastd zeug in eine eigene section "fastd" verschoben.
Ebenso für wireguard das "restrict" flag nach wirguard section verschoben.

bei den tests gab es bei fastd eine recursion bei den salt dependencies. ich habe das generieren der fastd keys aus den
autoconfig nach S53backbone-fastd2.sh verschoben und somit das zeug auch aus config.jinia und co rausgenommen.

dann habe ich hier im github noch den master-branch "protected" damit man nur über merge-requests mit approval mergen kann und nicht ausversehen durch push/force den master kaputt macht.

Das fastd zeug, habe ich in vorbereitung für das fastd22 (l2tp) erstmal sauber gemacht. fastd22 ist aber noch nix passiert.
VG
 Stephan