### PR TITLE
bmxd 1.4 + bugfixes

### DIFF
--- a/salt/freifunk/base/bmxd/etc/init.d/S52batmand
+++ b/salt/freifunk/base/bmxd/etc/init.d/S52batmand
@@ -104,7 +104,7 @@ OPTS="--throw-rules 0 --prio-rules 0"
 OPTS="${OPTS} --network $_ddmesh_meshnet --netid $MESH_NETWORK_ID --community_gateway ${COMMUNITY_SERVER}"
 # 10s OGM interval, purge timeout 35 -> 3 OGM
 # 5s OGM interval, purge timeout 35 -> 7 OGM
-OPTS="${OPTS} --hop_penalty 5 --lateness_penalty 10 --ogm_broadcasts 100 --udp_data_size 512 --ogm_interval 5000 --purge_timeout 35"
+OPTS="${OPTS} --hop_penalty 5 --lateness_penalty 10 --wireless_ogm_clone 100 --udp_data_size 512 --ogm_interval 5000 --purge_timeout 35"
 OPTS="${OPTS} --path_hysteresis 3"
 DAEMON_OPTS="${OPTS} $_IF"
  

--- a/salt/freifunk/base/bmxd/init.sls
+++ b/salt/freifunk/base/bmxd/init.sls
@@ -1,7 +1,7 @@
 {# FFDD Batmand Network #}
 {% from 'config.jinja' import freifunk_dl_url, nodeid, ddmesh_registerkey %}
 
-{% set bmxd_version = '1.2-7e90273293649e046a67dbada9de629d' %}
+{% set bmxd_version = '1.3-69f66bcd18906597da3ca39d7c7e701e' %}
 
 {% if salt['cmd.shell']("dpkg-query -W -f='${Version}' bmxd || true") != bmxd_version %}
 bmxd_pkg_removed:

--- a/salt/freifunk/base/bmxd/init.sls
+++ b/salt/freifunk/base/bmxd/init.sls
@@ -1,7 +1,7 @@
 {# FFDD Batmand Network #}
 {% from 'config.jinja' import freifunk_dl_url, nodeid, ddmesh_registerkey %}
 
-{% set bmxd_version = '1.3-69f66bcd18906597da3ca39d7c7e701e' %}
+{% set bmxd_version = '1.4-06cc61a82822f4dc98410fef1e00b81f' %}
 
 {% if salt['cmd.shell']("dpkg-query -W -f='${Version}' bmxd || true") != bmxd_version %}
 bmxd_pkg_removed:

--- a/salt/freifunk/base/ddmesh/var/www_freifunk/sysinfo.json
+++ b/salt/freifunk/base/ddmesh/var/www_freifunk/sysinfo.json
@@ -123,8 +123,8 @@ EOM
 				fi
 			done
 
-			rx=$(sudo /sbin/iptables -w -xvn -L stat_from_ovpn | awk '/RETURN/{print $2}')
-			tx=$(sudo /sbin/iptables -w -xvn -L stat_to_ovpn | awk '/RETURN/{print $2}')
+			rx=$(sudo iptables -w -xvn -L stat_from_ovpn | awk '/RETURN/{print $2}')
+			tx=$(sudo iptables -w -xvn -L stat_to_ovpn | awk '/RETURN/{print $2}')
 			echo "			\"traffic_ovpn\" : \"$rx,$tx\","
 
 cat<<EOM

--- a/salt/freifunk/base/ddmesh/var/www_freifunk/sysinfo.json
+++ b/salt/freifunk/base/ddmesh/var/www_freifunk/sysinfo.json
@@ -63,6 +63,7 @@ cat << EOM
 		},
 		"system":{
 			"uptime":"$(cat /proc/uptime)",
+			"uptime_string":"$(uptime)",
 			"uname":"$(uname -a)",
 			"nameserver": [ $(sed -n '/nameserver[ 	]\+10\.200/{s#[ 	]*nameserver[ 	]*\(.*\)#\t\t\t\t"\1",#;p}' /etc/resolv.conf | sed '$s#,##') ],
 			"date":"$(date)",

--- a/salt/freifunk/base/fastd/etc/init.d/S53backbone-fastd2
+++ b/salt/freifunk/base/fastd/etc/init.d/S53backbone-fastd2
@@ -155,10 +155,13 @@ case "$1" in
 	fi
 
 	generate_fastd_conf
+
 	# if fastd failes, return error to systemd, else salt always gets an active working status
 	# and would not restart fastd.
+
 	proc_fastd="$(ps x | grep -v grep | grep -c $DAEMON)"
-	if [ "$proc_fastd" -eq '0' ]; then
+	disable="$(uci -q ffdd.fastd.disable)"
+	if [ "$proc_fastd" -eq '0' -a "$disable" != "1" ]; then
 		# return error code to systemd to reflect correct status
 		"$DAEMON" --config "$FASTD_CONF" --pid-file "$PID_FILE" --daemon || exit 1
 	else
@@ -192,7 +195,12 @@ case "$1" in
   ;;
 
   get_public_key)
-	uci -qX get ffdd.fastd.public
+	disable="$(uci -q ffdd.fastd.disable)"
+	if [ "$disable" != "1" ]; then
+		uci -qX get ffdd.fastd.public
+	else
+		echo "---disabled---"
+	fi
   ;;
 
   add_accept)

--- a/salt/freifunk/base/fastd/etc/init.d/S53backbone-fastd2
+++ b/salt/freifunk/base/fastd/etc/init.d/S53backbone-fastd2
@@ -160,7 +160,7 @@ case "$1" in
 	# and would not restart fastd.
 
 	proc_fastd="$(ps x | grep -v grep | grep -c $DAEMON)"
-	disable="$(uci -q ffdd.fastd.disable)"
+	disable="$(uci -q get ffdd.fastd.disable)"
 	if [ "$proc_fastd" -eq '0' -a "$disable" != "1" ]; then
 		# return error code to systemd to reflect correct status
 		"$DAEMON" --config "$FASTD_CONF" --pid-file "$PID_FILE" --daemon || exit 1
@@ -195,7 +195,7 @@ case "$1" in
   ;;
 
   get_public_key)
-	disable="$(uci -q ffdd.fastd.disable)"
+	disable="$(uci -q get ffdd.fastd.disable)"
 	if [ "$disable" != "1" ]; then
 		uci -qX get ffdd.fastd.public
 	else

--- a/salt/freifunk/base/sudo/etc/sudoers
+++ b/salt/freifunk/base/sudo/etc/sudoers
@@ -20,6 +20,8 @@ Cmnd_Alias	BMXD=/usr/sbin/bmxd *
 Cmnd_Alias	INET_TUNNEL=/usr/local/bin/freifunk-gateway-info.sh *
 Cmnd_Alias	STAT_A=/sbin/iptables -w -xvn -L stat_from_ovpn
 Cmnd_Alias	STAT_B=/sbin/iptables -w -xvn -L stat_to_ovpn
+Cmnd_Alias	STAT_C=/usr/sbin/iptables -w -xvn -L stat_from_ovpn
+Cmnd_Alias	STAT_D=/usr/sbin/iptables -w -xvn -L stat_to_ovpn
 Cmnd_Alias	WG_BACKBONE=/usr/local/bin/wg-backbone.sh accept *
 
 # User privilege specification
@@ -28,6 +30,8 @@ www-data	ALL=NOPASSWD: BMXD
 www-data	ALL=NOPASSWD: INET_TUNNEL
 www-data	ALL=NOPASSWD: STAT_A
 www-data	ALL=NOPASSWD: STAT_B
+www-data	ALL=NOPASSWD: STAT_C
+www-data	ALL=NOPASSWD: STAT_D
 www-data	ALL=NOPASSWD: WG_BACKBONE
 
 # Allow members of group sudo to execute any command

--- a/salt/freifunk/base/uci/etc/config/ffdd
+++ b/salt/freifunk/base/uci/etc/config/ffdd
@@ -77,6 +77,9 @@ config fastd 'fastd'
 	option 'secret' '-'
 	option 'public' '-'
 
+	# allows to diable fastd. sysinfo.json will return "---disabled---" as public key to show user no valid key
+	option 'disable' '0'
+
 	# to accept all in comming backbone connection, set this to 0.
 	# When set to 1, only already known connections are accepted. this may be used
 	# to prevent overloading a server.

--- a/salt/freifunk/base/uci/usr/local/bin/uci_check_config_options.sh
+++ b/salt/freifunk/base/uci/usr/local/bin/uci_check_config_options.sh
@@ -27,6 +27,11 @@
 	test -z "$(uci -qX get ffdd.wireguard.restrict)" && uci -q set ffdd.wireguard.restrict=0
 
 
+## ffdd.fastd
+
+	test -z "$(uci -qX get ffdd.fastd.disable)" && uci -q set ffdd.fastd.disable=0
+
+
 ## finish / save uci config
 uci commit
 


### PR DESCRIPTION
**bmxd 1.4:** (sync to same as used in router firmware)
- potential memleak fix
- improve development traces / reduce some too

**other:**
- fix sudoers for iptables which is used by sysinfo.json to determine gw traffic (ovpn)
- fastd: add config to /etc/config/ffdd to disable fastd
- wireguard: sync wg registration (script) with the one used in firmware (to easier setting up connections between servers)